### PR TITLE
Fixed 'NameError: name 'file_' is not defined'

### DIFF
--- a/web/datasets/utils.py
+++ b/web/datasets/utils.py
@@ -704,8 +704,8 @@ def _fetch_file(url, data_dir=TEMP, uncompress=False, move=False,md5sum=None,
     # detecting already downloaded files)
     # Ex. glove.4B.zip -> glove.4B/glove.4B.zip
     if uncompress and not move:
-        dirname, _ = os.path.splitext(file_)
-        move = os.path.join(dirname, os.path.basename(file_))
+        dirname, _ = os.path.splitext(file_name)
+        move = os.path.join(dirname, os.path.basename(file_name))
 
     if (abort is None
         and not os.path.exists(target_file)


### PR DESCRIPTION
Hi.
I got an error message as I run 'evaluate_on_all.py':

> Traceback (most recent call last):
>   File "evaluate_on_all.py", line 55, in <module>
>     w = fetch_GloVe(corpus="wiki-6B", dim=300)
>   File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/web-0.0.1-py3.5.egg/web/embeddings.py", line 136, in fetch_GloVe
>     verbose=1)
>   File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/web-0.0.1-py3.5.egg/web/datasets/utils.py", line 707, in _fetch_file
>     dirname, _ = os.path.splitext(file_)
> **NameError: name 'file_' is not defined**

And a minor change of a variable name '**file_**' into '**file_name**' on line 707 of web/datasets/utils.py seems to solve this error. I hope this is a right solution.

Thanks for a great package!