### PR TITLE
Fix errors due to existing directories

### DIFF
--- a/web/datasets/utils.py
+++ b/web/datasets/utils.py
@@ -294,7 +294,7 @@ def _get_dataset_dir(sub_dir=None, data_dir=None, default_paths=None,
             path = os.path.join(path, sub_dir)
         if not os.path.exists(path):
             try:
-                os.makedirs(path)
+                os.makedirs(path, exist_ok=True)
                 if verbose > 0:
                     print('\nDataset created in %s\n' % path)
                 return path
@@ -477,8 +477,7 @@ def movetree(src, dst):
     names = os.listdir(src)
 
     # Create destination dir if it does not exist
-    if not os.path.exists(dst):
-        os.makedirs(dst)
+    os.makedirs(dst, exist_ok=True)
     errors = []
 
     for name in names:
@@ -566,8 +565,7 @@ def _fetch_file(url, data_dir=TEMP, uncompress=False, move=False,md5sum=None,
             data_dir = _get_dataset_dir(data_dir)
 
         # Determine data path
-        if not os.path.exists(data_dir):
-            os.makedirs(data_dir)
+        os.makedirs(data_dir, exist_ok=True)
 
         # Determine filename using URL
         parse = _urllib.parse.urlparse(url)
@@ -687,8 +685,7 @@ def _fetch_file(url, data_dir=TEMP, uncompress=False, move=False,md5sum=None,
     temp_dir = os.path.join(data_dir, files_md5)
 
     # Create destination dir
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir)
+    os.makedirs(data_dir, exist_ok=True)
 
     # Abortion flag, in case of error
     abort = None
@@ -738,15 +735,13 @@ def _fetch_file(url, data_dir=TEMP, uncompress=False, move=False,md5sum=None,
                          "not provided:\nURL:%s\nFile:%s" %
                          (url, target_file))
             else:
-                if not os.path.exists(os.path.dirname(temp_target_file)):
-                    os.makedirs(os.path.dirname(temp_target_file))
+                os.makedirs(os.path.dirname(temp_target_file), exist_ok=True)
                 open(temp_target_file, 'w').close()
 
         if move:
             move = os.path.join(data_dir, move)
             move_dir = os.path.dirname(move)
-            if not os.path.exists(move_dir):
-                os.makedirs(move_dir)
+            os.makedirs(move_dir, exist_ok=True)
             shutil.move(dl_file, move)
             dl_file = move
             target_file = dl_file

--- a/web/embeddings.py
+++ b/web/embeddings.py
@@ -130,10 +130,10 @@ def fetch_GloVe(dim=300, corpus="wiki-6B", normalize=True, lower=False, clean_wo
     assert corpus in download_file, "Unrecognized corpus"
     assert dim in embedding_file[corpus], "Not available dimensionality"
 
-    _ = _fetch_file(url=download_file[corpus],
-                           data_dir="embeddings",
-                           uncompress=True,
-                           verbose=1)
+    _fetch_file(url=download_file[corpus],
+                data_dir="embeddings",
+                uncompress=True,
+                verbose=1)
 
     return load_embedding(path.join(_get_dataset_dir("embeddings"), embedding_file[corpus][dim]),
                            format="glove",


### PR DESCRIPTION
`makedirs` failed despite the check for existing directories. Just use `exist_ok=True` instead.
Also, when one job raises an exception, instead of failing the whole script just collect the exceptions and raise at the end.