### PR TITLE
Fix stopiteration error

### DIFF
--- a/web/utils.py
+++ b/web/utils.py
@@ -67,7 +67,10 @@ def batched(iterable, size):
     sourceiter = iter(iterable)
     while True:
         batchiter = islice(sourceiter, size)
-        yield chain([next(batchiter)], batchiter)
+        try:
+            yield chain([next(batchiter)], batchiter)
+        except StopIteration:
+            return
 
 
 def _open(file_, mode='r'):


### PR DESCRIPTION
Hi,

Quote from this stack overflow [post](https://stackoverflow.com/questions/51700960/runtimeerror-generator-raised-stopiteration-every-time-i-try-to-run-app), starting from python 3.7, the `StopIteration ` exception will no longer be silently swallowed, which will cause the entire script to fail. This PR provides a quick fix to it with a simple change.